### PR TITLE
Make javafx.base a transitive dependency

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -3,5 +3,5 @@ module com.tobiasdiez.easybind {
     exports com.tobiasdiez.easybind.optional;
     exports com.tobiasdiez.easybind.select;
 
-    requires javafx.base;
+    requires transitive javafx.base;
 }


### PR DESCRIPTION
This fixes #30 and avoids downstream problems when using the module system. Currently you'd need to exclude javafx from easybind's dependencies to avoid ambiguity on non-linux systems, because Gradle seems to always put a `<classifier>` into the generated `pom.xml` [pointing to linux variant](https://repo1.maven.org/maven2/com/tobiasdiez/easybind/2.1.0/easybind-2.1.0.pom). You'd probably also like to investigate why this is in the first place...