### PR TITLE
Fix `MappedBackedList` handling of `wasUpdated` changes

### DIFF
--- a/src/main/java/com/tobiasdiez/easybind/MappedBackedList.java
+++ b/src/main/java/com/tobiasdiez/easybind/MappedBackedList.java
@@ -45,8 +45,8 @@ class MappedBackedList<E, F> extends TransformationList<E, F> implements EasyObs
                 }
                 nextPermutation(from, to, permutation);
             } else if (change.wasUpdated()) {
-                backingList.set(change.getFrom(), mapper.apply(getSource().get(change.getFrom())));
-                nextUpdate(change.getFrom());
+                E old = backingList.set(change.getFrom(), mapper.apply(getSource().get(change.getFrom())));
+                nextSet(change.getFrom(), old);
             } else {
                 if (change.wasRemoved()) {
                     int removePosition = change.getFrom();

--- a/src/test/java/com/tobiasdiez/easybind/MappedBackedListTest.java
+++ b/src/test/java/com/tobiasdiez/easybind/MappedBackedListTest.java
@@ -1,0 +1,31 @@
+package com.tobiasdiez.easybind;
+
+import javafx.beans.Observable;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.SortedList;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MappedBackedListTest {
+
+    @Test
+    public void testSortedListUpdatesWithMappedBackedList() {
+        ObservableList<IntegerProperty> list = FXCollections.observableArrayList(number -> new Observable[]{number});
+        ObservableList<Integer> mappedList = EasyBind.mapBacked(list, IntegerProperty::get);
+        SortedList<Integer> sortedList = new SortedList<>(mappedList);
+
+        IntegerProperty number = new SimpleIntegerProperty(1);
+        list.add(number);
+
+        assertEquals(1, sortedList.get(0));
+
+        number.set(2);
+
+        assertEquals(2, sortedList.get(0));
+    }
+}


### PR DESCRIPTION
This PR addresses an issue related to `EasyBind#mapBacked`. The problem arises when using a `SortedList` with elements that are mapped using `EasyBind#mapBacked`. Specifically, updates to elements in the list do not propagate to the `SortedList`.

Minimal Example:

```java
import javafx.beans.Observable;
import javafx.beans.property.IntegerProperty;
import javafx.beans.property.SimpleIntegerProperty;
import javafx.collections.FXCollections;
import javafx.collections.ObservableList;
import javafx.collections.transformation.SortedList;

import com.tobiasdiez.easybind.EasyBind;

public class Main {
    public static void main(String[] args) {
        ObservableList<IntegerProperty> list = FXCollections.observableArrayList(
                number -> new Observable[] {number}
        );
        ObservableList<Integer> mappedList = EasyBind.mapBacked(list, IntegerProperty::get);
        SortedList<Integer> sortedList = new SortedList<>(mappedList);

        IntegerProperty number = new SimpleIntegerProperty(1);
        list.add(number);

        System.out.println("mappedList: " + mappedList);
        System.out.println("sortedList: " + sortedList);

        number.set(2);

        System.out.println("mappedList: " + mappedList);
        System.out.println("sortedList: " + sortedList);
    }
}
```

Output:
```
mappedList: [1]
sortedList: [1]
mappedList: [2]
sortedList: [1]
```

Expected Output:
```
mappedList: [1]
sortedList: [1]
mappedList: [2]
sortedList: [2]
```


The issue is due to the `SortedList#sourceChanged` method in JavaFX. If there is no custom comparator, `SortedList#updateUnsorted` will handle the updates, but it does not handle the `wasUpdated` change. This results in the `SortedList` not updating when an element's change type is `wasUpdated`.

Reference to the code:
[SortedList#sourceChanged](https://github.com/openjdk/jfx/blob/1117c15ea1c6038f708e59ca8d9af2837db73153/modules/javafx.base/src/main/java/javafx/collections/transformation/SortedList.java#L101)
[SortedList#updateUnsorted](https://github.com/openjdk/jfx/blob/1117c15ea1c6038f708e59ca8d9af2837db73153/modules/javafx.base/src/main/java/javafx/collections/transformation/SortedList.java#L243-L278)

The fix involves using `nextSet`, which is equivalent to calling `nextRemove()` followed by `nextAdd()`. This ensures that updates to elements are correctly propagated through to the `SortedList`.